### PR TITLE
Sexual attention is unwanted at RailsBridge

### DIFF
--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -7,7 +7,7 @@ title: Code of Conduct
 
 <p>We want all attendees to have an enjoyable and fulfilling experience. Accordingly, all attendees are expected to show respect and courtesy to other attendees throughout the workshop events.</p>
 
-<p>RailsBridge Cape Town is dedicated to providing a harassment-free experience for everyone regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion. We will not tolerate harassment of workshop participants in any form, be it verbal comments, imagery, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of lectures, inappropriate physical contact, and unwelcome sexual attention.</p>
+<p>RailsBridge Cape Town is dedicated to providing a harassment-free experience for everyone regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion. We will not tolerate harassment of workshop participants in any form, be it verbal comments, imagery, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of lectures, inappropriate physical contact, and sexual attention.</p>
 
 <p>Workshop participants violating these rules may be sanctioned or expelled from the event at the discretion of the organizers.</p>
 

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -7,7 +7,7 @@ title: Code of Conduct
 
 <p>We want all attendees to have an enjoyable and fulfilling experience. Accordingly, all attendees are expected to show respect and courtesy to other attendees throughout the workshop events.</p>
 
-<p>RailsBridge Cape Town is dedicated to providing a harassment-free experience for everyone regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion. We will not tolerate harassment of workshop participants in any form, be it verbal comments, imagery, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of lectures, inappropriate physical contact, and sexual attention.</p>
+<p>RailsBridge Cape Town is dedicated to providing a harassment-free experience for everyone regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion. We will not tolerate harassment of workshop participants in any form, be it verbal comments, imagery, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of lectures, inappropriate physical contact, or sexual attention.</p>
 
 <p>Workshop participants violating these rules may be sanctioned or expelled from the event at the discretion of the organizers.</p>
 


### PR DESCRIPTION
Operating from the perspective that many offences originate from poor judgment rather than malice, place sexual attention outside the code of conduct entirely, rather than making it a judgment call.
