### PR TITLE
Tidy up contact deets

### DIFF
--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -3,7 +3,7 @@
   <h2 id="contact" class="section-header">Contact</h2>
 
   <p>
-    Want to get in touch? Email us at <a href="mailto:hello@railsbridgecapetown.org">hello@railsbridgecapetown.org</a> or find us on Twitter at <a href="https://twitter.com/RailsBridgeCPT">@RailsBridgeCPT</a>.
+    Want to get in touch? You can email us at <a href="mailto:hello@railsbridgecapetown.org">hello@railsbridgecapetown.org</a>, <a href="https://www.meetup.com/RailsBridge-Cape-Town/members/?op=leaders">message us on meetup</a>, find us on Twitter as <a href="https://twitter.com/RailsBridgeCPT">@RailsBridgeCPT</a>, or on <a href="https://zatech.slack.com/messages/railsbridge/">RailsBridge channel of the ZA Tech Slack</a> (you can <a href="http://zatech.co.za">sign yourself up</a> for an account).
   </p>
 
 </section>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -5,8 +5,7 @@
     <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
     <li><a href="/resources.html">Resources</a></li>
     <li><a href="/sponsorship.html">Sponsorship</a></li>
-    <li><a href="http://www.meetup.com/RailsBridge-Cape-Town/members/?op=leaders">Contact us via meetup</a></li>
-    <li><a href="mailto:hello@railsbridgecapetown.org">Contact us via email</a></li>
+    <li><a href="/#contact">Contact us</a></li>
   </ul>
 </nav>
 

--- a/_includes/our-workshops.html
+++ b/_includes/our-workshops.html
@@ -17,6 +17,4 @@
 
   <p class="cta"><a href="http://www.meetup.com/RailsBridge-Cape-Town/">Join our meetup group for details of our next event.</a></p>
 
-  <p>You can also follow us on Twitter <a href="https://twitter.com/RailsBridgeCPT">@RailsBridgeCPT</a>.</p>
-
 </section>

--- a/_includes/railsbridge.html
+++ b/_includes/railsbridge.html
@@ -27,8 +27,4 @@
     </li>
   </ul>
 
-  <p>
-    Follow us on Twitter <a href="https://twitter.com/RailsBridgeCPT">@RailsBridgeCPT</a>
-  </p>
-
 </section>


### PR DESCRIPTION
- We've got our Twitter deets all over the page, which seems a bit unnecessary.
- We're using the ZA Tech Slack as a contact point.